### PR TITLE
New type __gnupg_key

### DIFF
--- a/type/__gnupg_key/explorer/ownertrust
+++ b/type/__gnupg_key/explorer/ownertrust
@@ -1,0 +1,56 @@
+#!/bin/sh -e
+#
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-extra.
+#
+# skonfig-extra is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-extra is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-extra. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints the current ownertrust of the public key
+#
+
+GNUPGHOME=$(cat "${__object:?}/parameter/homedir")
+export GNUPGHOME
+
+test -d "${GNUPGHOME-}" || {
+	# no GNUPGHOME, no key
+	exit 0
+}
+
+command -v gpg >/dev/null 2>&1 || {
+	# assume that if gpg is not installed, the key is also not imported
+	exit 0
+}
+
+if test -f "${__object:?}/parameter/key-id"
+then
+	read -r keyid <"${__object:?}/parameter/key-id"
+else
+	keyid=${__object_id:?}
+fi
+
+case ${#keyid}
+in
+	(40)
+		;;
+	(*)
+		# convert key ID to fingerprint
+		keyid=$(
+			gpg --fingerprint --with-colons --list-keys "${keyid}" \
+			| awk -F: '/^fpr:/ { print $10; exit }')
+		;;
+esac
+
+gpg --homedir "${GNUPGHOME:?}" --export-ownertrust \
+| awk -F: -v keyid="${keyid}" 'keyid == $1 { print $2 }'

--- a/type/__gnupg_key/explorer/pub-data
+++ b/type/__gnupg_key/explorer/pub-data
@@ -1,0 +1,46 @@
+#!/bin/sh -e
+#
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-extra.
+#
+# skonfig-extra is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-extra is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-extra. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints the public key information in machine readable form.
+#
+
+GNUPGHOME=$(cat "${__object:?}/parameter/homedir")
+export GNUPGHOME
+
+test -d "${GNUPGHOME-}" || {
+	# no GNUPGHOME, no key
+	exit 0
+}
+
+command -v gpg >/dev/null 2>&1 || {
+	# assume that if gpg is not installed, the key is also not imported
+	exit 0
+}
+
+if test -f "${__object:?}/parameter/key-id"
+then
+	read -r keyid <"${__object:?}/parameter/key-id"
+else
+	keyid=${__object_id:?}
+fi
+
+# silence stderr because --list-keys prints an error message if the key is not in the keyring
+# https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=doc/DETAILS
+gpg --homedir "${GNUPGHOME:?}" --with-colons --list-keys "${keyid}" 2>/dev/null \
+| grep -v '^tru:' || :

--- a/type/__gnupg_key/explorer/remote-object
+++ b/type/__gnupg_key/explorer/remote-object
@@ -1,0 +1,23 @@
+#!/bin/sh -e
+#
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-extra.
+#
+# skonfig-extra is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-extra is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-extra. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints the path of the remote $__object
+#
+
+printf '%s\n' "${__object:?}"

--- a/type/__gnupg_key/explorer/sec-data
+++ b/type/__gnupg_key/explorer/sec-data
@@ -1,0 +1,46 @@
+#!/bin/sh -e
+#
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-extra.
+#
+# skonfig-extra is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-extra is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-extra. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints the public key information in machine readable form.
+#
+
+GNUPGHOME=$(cat "${__object:?}/parameter/homedir")
+export GNUPGHOME
+
+test -d "${GNUPGHOME-}" || {
+	# no GNUPGHOME, no key
+	exit 0
+}
+
+command -v gpg >/dev/null 2>&1 || {
+	# assume that if gpg is not installed, the key is also not imported
+	exit 0
+}
+
+if test -f "${__object:?}/parameter/key-id"
+then
+	read -r keyid <"${__object:?}/parameter/key-id"
+else
+	keyid=${__object_id:?}
+fi
+
+# silence stderr because --list-keys prints an error message if the key is not in the keyring
+# https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=doc/DETAILS
+gpg --homedir "${GNUPGHOME:?}" --with-colons --list-secret-keys "${keyid}" 2>/dev/null \
+| grep -v '^tru:' || :

--- a/type/__gnupg_key/gencode-local
+++ b/type/__gnupg_key/gencode-local
@@ -60,6 +60,10 @@ test -f "${__object:?}/parameter/source" || exit 0
 key_source=$(cat "${__object:?}/parameter/source")
 case ${key_source-}
 in
+	(hkp://*|hkps://*|ldap://*|ldaps://*)
+		# key server addresses
+		exit 0
+		;;
 	(http://*|https://*)
 		# download
 		src_file="${__object:?}/files/download.gpg"
@@ -82,8 +86,12 @@ test -s "${src_file}" || {
 	exit 1
 }
 
-__remote_object=$(cat "${__object:?}/explorer/remote-object")
-remote_cmd="mkdir $(shquot "${__remote_object:?}/files") && cat >$(shquot "${__remote_object:?}/files/src.gpg")"
+__object_remote=$(cat "${__object:?}/explorer/remote-object")
+remote_input_file="${__object_remote:?}/files/src.gpg"
+
+printf '%s\n' "${remote_input_file}" >"${__object:?}/files/remote-input-file"
+
+remote_cmd="mkdir $(shquot "${remote_input_file%/*}") && cat >$(shquot "${remote_input_file:?}")"
 printf '%s %s %s <%s\n' \
 	"${__remote_exec:?}" "$(shquot "${__target_host:?}")" \
 	"$(shquot "${remote_cmd}")" \

--- a/type/__gnupg_key/gencode-local
+++ b/type/__gnupg_key/gencode-local
@@ -1,0 +1,90 @@
+#!/bin/sh -e
+#
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-extra.
+#
+# skonfig-extra is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-extra is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-extra. If not, see <http://www.gnu.org/licenses/>.
+#
+
+shquot() {
+	sed -e "s/'/'\\\\''/g" -e "1s/^/'/" -e "\$s/\$/'/" <<-EOF
+	$*
+	EOF
+}
+
+version_ge() {
+	sort <<-EOF -t. -r -n | { read -r x; test "${x}" = "$1"; }
+	$1
+	$2
+	EOF
+}
+
+read -r state_should <"${__object:?}/parameter/state"
+
+# initialise files directory (communication with gencode-remote)
+mkdir "${__object:?}/files"
+
+# check if --state present and --source (otherwise, gencode-local does not need
+# to do anything)
+test "${state_should}" = 'present' || exit 0
+
+if test -s "${__object:?}/explorer/pub-data" \
+	|| test -s "${__object:?}/explorer/sec-data"
+then
+	# already exists
+	exit 0
+else
+	# key does not exist, it needs to be imported
+
+	# create the needs-update file to signal to gencode-remote that a new key
+	# needs to be imported and that, if needed, the source file was copied to
+	# the target
+	touch "${__object:?}/files/needs-update"
+fi
+
+test -f "${__object:?}/parameter/source" || exit 0
+
+# if we get here, the key needs to be uploaded to the target
+key_source=$(cat "${__object:?}/parameter/source")
+case ${key_source-}
+in
+	(http://*|https://*)
+		# download
+		src_file="${__object:?}/files/download.gpg"
+
+		python3 -c 'import sys, urllib.request; urllib.request.urlretrieve(sys.argv[1], filename=sys.argv[2]); urllib.request.urlcleanup()' \
+			"${key_source}" "${src_file}"
+		;;
+	('-')
+		# stdin
+		src_file="${__object:?}/stdin"
+		;;
+	(file://*|*)
+		# assume file
+		src_file=${key_source#file://}
+		;;
+esac
+
+test -s "${src_file}" || {
+	printf 'cannot find key source: %s\n' "${key_source}" >&2
+	exit 1
+}
+
+__remote_object=$(cat "${__object:?}/explorer/remote-object")
+remote_cmd="mkdir $(shquot "${__remote_object:?}/files") && cat >$(shquot "${__remote_object:?}/files/src.gpg")"
+printf '%s %s %s <%s\n' \
+	"${__remote_exec:?}" "$(shquot "${__target_host:?}")" \
+	"$(shquot "${remote_cmd}")" \
+	"$(shquot "${src_file}")"

--- a/type/__gnupg_key/gencode-remote
+++ b/type/__gnupg_key/gencode-remote
@@ -1,0 +1,82 @@
+#!/bin/sh -e
+#
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-extra.
+#
+# skonfig-extra is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-extra is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-extra. If not, see <http://www.gnu.org/licenses/>.
+#
+
+shquot() {
+	sed -e "s/'/'\\\\''/g" -e "1s/^/'/" -e "\$s/\$/'/" <<-EOF
+	$*
+	EOF
+}
+
+GNUPGHOME_remote=$(cat "${__object:?}/parameter/homedir")
+if test -f "${__object:?}/parameter/key-id"
+then
+	read -r keyid <"${__object:?}/parameter/key-id"
+else
+	keyid=${__object_id:?}
+fi
+read -r state_should <"${__object:?}/parameter/state"
+
+
+case ${state_should}
+in
+	(present)
+		test -f "${__object:?}/files/needs-update" || exit 0
+
+		if test -f "${__object:?}/parameter/source"
+		then
+			# "manual" source, use uploaded file from code-remote
+			printf 'gpg --homedir %s --batch --no-autostart --import "${__object:?}/files/src.gpg"\n' \
+				"$(shquot "${GNUPGHOME_remote:?}")"
+		else
+			# auto key locate
+			gpgopts=
+			if test -f "${__object:?}/parameter/key-locate-mechanisms"
+			then
+				while read -r _mechanisms
+				do
+					gpgopts="${gpgopts-} --auto-key-locate $(shquot "${_mechanisms}")"
+				done <"${__object:?}/parameter/key-locate-mechanisms"
+				unset -v _mechanisms
+			fi
+
+			printf 'gpg --homedir %s%s --batch --locate-external-keys %s\n' \
+				"$(shquot "${GNUPGHOME_remote:?}")" "${gpgopts}" "$(shquot "${keyid}")"
+		fi
+		;;
+	(absent)
+		# XXX: think again about using --yes for deleting keys.
+
+		if test -s "${__object:?}/explorer/pub-data"
+		then
+			printf 'gpg --homedir %s --batch --yes --delete-keys %s\n' \
+				"$(shquot "${GNUPGHOME_remote:?}")" "$(shquot "${keyid}")"
+		fi
+
+		if test -s "${__object:?}/explorer/sec-data"
+		then
+			printf 'gpg --homedir %s --batch --yes --delete-secret-keys %s\n' \
+				"$(shquot "${GNUPGHOME_remote:?}")" "$(shquot "${keyid}")"
+		fi
+		;;
+	(*)
+		printf 'Invalid --state: %s\n' "${state_should-}" >&2
+		exit 1
+		;;
+esac

--- a/type/__gnupg_key/gencode-remote
+++ b/type/__gnupg_key/gencode-remote
@@ -58,24 +58,23 @@ in
 	(present)
 		if test -f "${__object:?}/files/needs-update"
 		then
-			if test -f "${__object:?}/parameter/source"
+			if test -f "${__object:?}/files/remote-input-file"
 			then
 				# "manual" source, use uploaded file from code-remote
-				printf 'gpg --homedir %s --batch --no-autostart --import "${__object:?}/files/src.gpg"\n' \
-					"$(shquot "${GNUPGHOME_remote:?}")"
+				remote_input_file=$(cat "${__object:?}/files/remote-input-file")
+
+				printf 'gpg --homedir %s --batch --no-autostart --import %s\n' \
+					"$(shquot "${GNUPGHOME_remote:?}")" \
+					"$(shquot "${remote_input_file:?}")"
 			else
-				# auto key locate
+				# receive from keyserver
 				gpgopts=
-				if test -f "${__object:?}/parameter/key-locate-mechanisms"
+				if test -f "${__object:?}/parameter/source"
 				then
-					while read -r _mechanisms
-					do
-						gpgopts="${gpgopts-} --auto-key-locate $(shquot "${_mechanisms}")"
-					done <"${__object:?}/parameter/key-locate-mechanisms"
-					unset -v _mechanisms
+					gpgopts="${gpgopts-} --keyserver $(shquot "$(cat "${__object:?}/parameter/source")")"
 				fi
 
-				printf 'gpg --homedir %s%s --batch --locate-external-keys %s\n' \
+				printf 'gpg --homedir %s%s --batch --recv-key %s\n' \
 					"$(shquot "${GNUPGHOME_remote:?}")" "${gpgopts}" \
 					"$(shquot "${keyid}")"
 			fi

--- a/type/__gnupg_key/gencode-remote
+++ b/type/__gnupg_key/gencode-remote
@@ -24,6 +24,25 @@ shquot() {
 	EOF
 }
 
+map_ownertrust_s() {
+	# https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=g10/trustdb.h;hb=gnupg-2.4.1#l28
+	case $1
+	in
+		(undefined)
+			echo 2 ;;
+		(never)
+			echo 3 ;;
+		(marginal)
+			echo 4 ;;
+		(full|fully)
+			echo 5 ;;
+		(ultimate)
+			echo 6 ;;
+		(*)
+			return 1 ;;
+	esac
+}
+
 GNUPGHOME_remote=$(cat "${__object:?}/parameter/homedir")
 if test -f "${__object:?}/parameter/key-id"
 then
@@ -37,27 +56,59 @@ read -r state_should <"${__object:?}/parameter/state"
 case ${state_should}
 in
 	(present)
-		test -f "${__object:?}/files/needs-update" || exit 0
-
-		if test -f "${__object:?}/parameter/source"
+		if test -f "${__object:?}/files/needs-update"
 		then
-			# "manual" source, use uploaded file from code-remote
-			printf 'gpg --homedir %s --batch --no-autostart --import "${__object:?}/files/src.gpg"\n' \
-				"$(shquot "${GNUPGHOME_remote:?}")"
-		else
-			# auto key locate
-			gpgopts=
-			if test -f "${__object:?}/parameter/key-locate-mechanisms"
+			if test -f "${__object:?}/parameter/source"
 			then
-				while read -r _mechanisms
-				do
-					gpgopts="${gpgopts-} --auto-key-locate $(shquot "${_mechanisms}")"
-				done <"${__object:?}/parameter/key-locate-mechanisms"
-				unset -v _mechanisms
-			fi
+				# "manual" source, use uploaded file from code-remote
+				printf 'gpg --homedir %s --batch --no-autostart --import "${__object:?}/files/src.gpg"\n' \
+					"$(shquot "${GNUPGHOME_remote:?}")"
+			else
+				# auto key locate
+				gpgopts=
+				if test -f "${__object:?}/parameter/key-locate-mechanisms"
+				then
+					while read -r _mechanisms
+					do
+						gpgopts="${gpgopts-} --auto-key-locate $(shquot "${_mechanisms}")"
+					done <"${__object:?}/parameter/key-locate-mechanisms"
+					unset -v _mechanisms
+				fi
 
-			printf 'gpg --homedir %s%s --batch --locate-external-keys %s\n' \
-				"$(shquot "${GNUPGHOME_remote:?}")" "${gpgopts}" "$(shquot "${keyid}")"
+				printf 'gpg --homedir %s%s --batch --locate-external-keys %s\n' \
+					"$(shquot "${GNUPGHOME_remote:?}")" "${gpgopts}" \
+					"$(shquot "${keyid}")"
+			fi
+		fi
+
+		if test -f "${__object:?}/parameter/ownertrust"
+		then
+			read -r ownertrust_is <"${__object:?}/explorer/ownertrust" || :
+			read -r ownertrust_should_s <"${__object:?}/parameter/ownertrust"
+
+			ownertrust_should=$(map_ownertrust_s "${ownertrust_should_s}") || {
+				printf 'Invalid --ownertrust: %s\n' "${ownertrust_should_s-}" >&2
+				exit 1
+			}
+
+			if test "${ownertrust_is}" != "${ownertrust_should}"
+			then
+				# update ownertrust
+				case ${#keyid}
+				in
+					(40)
+						;;
+					(*)
+						printf 'key ID must be a fingerprint to set ownertrust' >&2
+						exit 1
+						;;
+				esac
+
+				printf "echo '%s:%u:' | gpg --homedir %s --batch --import-ownertrust\n" \
+					"${keyid}" \
+					$((ownertrust_should)) \
+					"$(shquot "${GNUPGHOME_remote:?}")"
+			fi
 		fi
 		;;
 	(absent)

--- a/type/__gnupg_key/man.rst
+++ b/type/__gnupg_key/man.rst
@@ -47,6 +47,21 @@ key-locate-mechanisms
    be concatenated by :strong:`gpg`\ (1).
 
    Hint: this parameter also accepts keyserver URLs.
+ownertrust
+   Set the ownertrust of the imported key to the given value.
+
+   The value must be one of:
+
+   undefined
+      not enough information to assign an ownertrust
+   never
+      never trusted
+   marginal
+      marginally trusted
+   fully
+      fully trusted
+   ultimate
+      ultimately trusted
 source
    the source to take the key from.
    Will use auto-key-locate if not used.

--- a/type/__gnupg_key/man.rst
+++ b/type/__gnupg_key/man.rst
@@ -10,11 +10,11 @@ DESCRIPTION
 -----------
 This type can be used to manage PGP keys inside `GnuPG <https://www.gnupg.org>`_
 keyrings.
-Keys can be retrieved from files (either local or via HTTP) or automatically
-found and imported using :strong:`gpg`\ (1)'s ``--locate-keys`` feature.
+Keys can be retrieved from files (either local or via HTTP) or imported from a
+keyserver.
 
 Because the PGP file format is complex, this type requires that you give it the
-key ID even if you import from a file/URL.
+full key ID (i.e. fingerprint) of the primary key even if you import from a file/URL.
 
 Once a key is present in the keyring, this type will not process it further,
 i.e. it won't update the keyring if e.g. new signatures or sub keys were added.
@@ -32,23 +32,14 @@ homedir
 
    Defaults to: ``/root/.gnupg``
 key-id
-   the PGP key id of the key to import or of the key in ``--source``.
-   The value of this parameter is used to check if the key already exists, so
-   it does not necessarily have to be an ID, but it should be unique, especially
-   for ``--state absent`` :-).
+   the PGP key id of the key to receive when importing from a keyserver or of
+   the key in ``--source`` when importing from a file.
+
+   The value of this parameter is used to check if the key already exists.
 
    Defaults to: ``__object_id``
-key-locate-mechanisms
-   this parameter takes any number of GnuPG ``--auto-key-locate`` mechanisms.
-   If a key needs to be fetched, these mechanisms will be tried in the order
-   listed in this parameter.
-
-   This parameter can be used multiple times. The values of all instances will
-   be concatenated by :strong:`gpg`\ (1).
-
-   Hint: this parameter also accepts keyserver URLs.
 ownertrust
-   Set the ownertrust of the imported key to the given value.
+   set the ownertrust of the imported key to the given value.
 
    The value must be one of:
 
@@ -64,16 +55,19 @@ ownertrust
       ultimately trusted
 source
    the source to take the key from.
-   Will use auto-key-locate if not used.
 
    Acceptable values:
 
    ``http://...`` / ``https://...``
-      key file downloaded from the web.
+      key file downloaded from the web
+   ``hkp://...`` / ``hkps://...``
+      receive public key from an HTTP (compatible) keyserver
+   ``ldap://...`` / ``ldaps://...``
+      receive public key from an LDAP keyserver
    ``file://...`` / ``/...``
-      files local to the config host
+      key file local to the config host
    ``-``
-      stdin
+      read key data from standard input
 state
    One of:
 
@@ -101,13 +95,13 @@ EXAMPLES
    __gnupg_key 453B65310595562855471199CA68BE8010084C9C \
       --source https://download.libvirt.org/gpg_key.asc
 
-   # import a PGP key from a keyserver/WKD
-   __gnupg_key wk@gnupg.org
+   # import a PGP key from the default keyserver
+   __gnupg_key AEA84EDCF01AD86C4701C85C63113AE866587D0A
 
    # import a PGP key from a specific keyserver
    __gnupg_key openzfs-release-key \
-      --key-id bass6@llnl.gov \
-      --key-locate-mechanisms clear,'hkps://pgp.mit.edu'
+      --key-id 29D5610EAE2941E355A2FE8AB97467AAC77B9667 \
+      --source 'hkps://pgp.mit.edu'
 
 
 SEE ALSO

--- a/type/__gnupg_key/man.rst
+++ b/type/__gnupg_key/man.rst
@@ -1,0 +1,113 @@
+cdist-type__gnupg_key(7)
+========================
+
+NAME
+----
+cdist-type__gnupg_key - Manage GnuPG keys
+
+
+DESCRIPTION
+-----------
+This type can be used to manage PGP keys inside `GnuPG <https://www.gnupg.org>`_
+keyrings.
+Keys can be retrieved from files (either local or via HTTP) or automatically
+found and imported using :strong:`gpg`\ (1)'s ``--locate-keys`` feature.
+
+Because the PGP file format is complex, this type requires that you give it the
+key ID even if you import from a file/URL.
+
+Once a key is present in the keyring, this type will not process it further,
+i.e. it won't update the keyring if e.g. new signatures or sub keys were added.
+
+
+REQUIRED PARAMETERS
+-------------------
+None.
+
+
+OPTIONAL PARAMETERS
+-------------------
+homedir
+   the path of the GnuPG home directory.
+
+   Defaults to: ``/root/.gnupg``
+key-id
+   the PGP key id of the key to import or of the key in ``--source``.
+   The value of this parameter is used to check if the key already exists, so
+   it does not necessarily have to be an ID, but it should be unique, especially
+   for ``--state absent`` :-).
+
+   Defaults to: ``__object_id``
+key-locate-mechanisms
+   this parameter takes any number of GnuPG ``--auto-key-locate`` mechanisms.
+   If a key needs to be fetched, these mechanisms will be tried in the order
+   listed in this parameter.
+
+   This parameter can be used multiple times. The values of all instances will
+   be concatenated by :strong:`gpg`\ (1).
+
+   Hint: this parameter also accepts keyserver URLs.
+source
+   the source to take the key from.
+   Will use auto-key-locate if not used.
+
+   Acceptable values:
+
+   ``http://...`` / ``https://...``
+      key file downloaded from the web.
+   ``file://...`` / ``/...``
+      files local to the config host
+   ``-``
+      stdin
+state
+   One of:
+
+   present
+      the key is available in the keyring
+   absent
+      the key is missing from the keyring
+
+
+BOOLEAN PARAMETERS
+------------------
+None.
+
+
+EXAMPLES
+--------
+
+.. code-block:: sh
+
+   # import a PGP key from file
+   __gnupg_key 3F7121B3B286715A3325234E536E504BD7E91E76 \
+      --source "${__files:?}/pgp/7E91E764.asc"
+
+   # import a PGP key from the web
+   __gnupg_key 453B65310595562855471199CA68BE8010084C9C \
+      --source https://download.libvirt.org/gpg_key.asc
+
+   # import a PGP key from a keyserver/WKD
+   __gnupg_key wk@gnupg.org
+
+   # import a PGP key from a specific keyserver
+   __gnupg_key openzfs-release-key \
+      --key-id bass6@llnl.gov \
+      --key-locate-mechanisms clear,'hkps://pgp.mit.edu'
+
+
+SEE ALSO
+--------
+:strong:`gpg`\ (1)
+
+
+AUTHORS
+-------
+| Dennis Camera <dennis.camera--@--riiengineering.ch>
+
+
+COPYING
+-------
+Copyright \(C) 2023 Dennis Camera.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__gnupg_key/manifest
+++ b/type/__gnupg_key/manifest
@@ -1,0 +1,60 @@
+#!/bin/sh -e
+#
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-extra.
+#
+# skonfig-extra is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-extra is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-extra. If not, see <http://www.gnu.org/licenses/>.
+#
+
+os=$(cat "${__global:?}/explorer/os")
+
+read -r state_should <"${__object:?}/parameter/state"
+
+case ${os}
+in
+	(alpine|archlinux|freebsd|openbsd)
+		package_name=gnupg
+		;;
+	(debian|devuan|ubuntu)
+		package_name=gnupg
+		;;
+	(centos|almalinux|eurolinux|rocky|fedora|redhat|scientific)
+		package_name=gnupg
+		;;
+	(gentoo)
+		package_name=app-crypt/gnupg
+		;;
+	(netbsd)
+		package_name=security/gnupg2
+		;;
+	(suse)
+		package_name=gpg2
+		;;
+	(*)
+		: "${__type:?}"  # make shellcheck happy
+		printf "Your operating system (%s) is currently not supported by this type (%s)\n" "${os}" "${__type##*/}" >&2
+		printf "Please contribute an implementation for it if you can.\n" >&2
+		exit 1
+		;;
+esac
+
+if test "${state_should}" != 'absent' \
+	|| test -s "${__object:?}/explorer/pub-data" \
+	|| test -s "${__object:?}/explorer/sec-data"
+then
+	# the package is only required if a key is to be installed or it exists and
+	# needs to be removed
+	__package "${package_name}"
+fi

--- a/type/__gnupg_key/parameter/default/homedir
+++ b/type/__gnupg_key/parameter/default/homedir
@@ -1,0 +1,1 @@
+/root/.gnupg

--- a/type/__gnupg_key/parameter/default/state
+++ b/type/__gnupg_key/parameter/default/state
@@ -1,0 +1,1 @@
+present

--- a/type/__gnupg_key/parameter/optional
+++ b/type/__gnupg_key/parameter/optional
@@ -1,0 +1,4 @@
+homedir
+key-id
+source
+state

--- a/type/__gnupg_key/parameter/optional
+++ b/type/__gnupg_key/parameter/optional
@@ -1,4 +1,5 @@
 homedir
 key-id
+ownertrust
 source
 state

--- a/type/__gnupg_key/parameter/optional_multiple
+++ b/type/__gnupg_key/parameter/optional_multiple
@@ -1,0 +1,1 @@
+key-locate-mechanisms

--- a/type/__gnupg_key/parameter/optional_multiple
+++ b/type/__gnupg_key/parameter/optional_multiple
@@ -1,1 +1,0 @@
-key-locate-mechanisms


### PR DESCRIPTION
This PR adds a new type (`__gnupg_key`) to manage PGP keys with [GnuPG](https://www.gnupg.org).

At this point in time it is only an RFC, because implementing this functionally turned out to be more complex than it may seem at first.

This RFC includes two ways to source keys:

1. "file based" approach (the file can either be local to the config host (including stdin) or be downloaded via HTTP),
2. automatic key lookup using `--locate-keys`.

For "file-sourced" keys it is non-trivial to check if a key already exists in a keyring, so I added a `--key-id` parameter which is used to check if the key already exists.
However, `--locate-keys` does not always work as expected with key IDs. It works better with email addresses.

Identifying keys with email addresses, on the other hand, can be problematic because there can be different keys for the same email address.
Further, GnuPG does not require full email addresses, e.g. it happily deletes a key identified only by the domain part of an email.
Should such imprecise identifiers be accepted?

Does this approach (file-sourced keys + `--key-locate`) make sense?
Or can we assume that in a config management scenario keys are always identified by key IDs/fingerprints with a known and defined source?
If so, the `--key-locate` approach could be rewritten to use the more "classic" `gpg --keyserver --recv-keys` and the keyserver could be specified in `--source` too.

There is also currently nothing which allows to update an already existing key if e.g. new signatures or sub keys were added.
I tried to implement this functionality at least for the file-sourced keys, but I couldn't find a solution.
There is `--show-keys` in newer versions of GnuPG, but things get complex when a file contains multiple keys, e.g. a public and private key pair or multiple different public keys (e.g. https://downloads.apache.org/httpd/KEYS).
Any ideas? Is this functionality important?

