### PR TITLE
__unbound: Deprecate

### DIFF
--- a/type/__unbound/deprecated
+++ b/type/__unbound/deprecated
@@ -1,0 +1,1 @@
+Please switch to using the __unbound set (https://github.com/skonfig/__unbound) where further development is taking place.


### PR DESCRIPTION
I started to write a set to configure unbound in a more flexible way.
I propose to continue further development in [skonfig/__unbound](https://github.com/skonfig/__unbound) and deprecate the extra type, even if the set is not a drop-in replacement.