### PR TITLE
__openzfs: Don't automatically enable backports

### DIFF
--- a/type/__openzfs/man.rst
+++ b/type/__openzfs/man.rst
@@ -10,7 +10,7 @@ DESCRIPTION
 -----------
 This type can be used to set up OpenZFS on the system and set tunables.
 
-This type only works on Debian derivatives.
+**NOTE:** This type only works on Debian derivatives.
 
 
 REQUIRED PARAMETERS
@@ -50,8 +50,20 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Make sure OpenZFS is installed on the target.
-    __openzfs
+   # Make sure OpenZFS is installed on the target.
+   __openzfs
+
+   # Install OpenZFS from backports to get a newer version
+   __apt_backports \
+      --component main \
+      --component contrib
+   require=__apt_backports/ \
+   __apt_pin zfs-backports \
+      --package 'src:zfs-linux' \
+      --release 'n=*-backports*' \
+      --priority 600
+   require=__apt_pin/zfs-backports \
+   __openzfs
 
 
 SEE ALSO
@@ -62,12 +74,12 @@ SEE ALSO
 
 AUTHORS
 -------
-Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING
 -------
-Copyright \(C) 2020-2023 Dennis Camera.
+Copyright \(C) 2020-2024 Dennis Camera.
 You can redistribute it and/or modify it under the terms of the GNU General
 Public License as published by the Free Software Foundation, either version 3
 of the License, or (at your option) any later version.

--- a/type/__openzfs/manifest
+++ b/type/__openzfs/manifest
@@ -57,14 +57,7 @@ os=$(cat "${__global:?}/explorer/os")
 case ${os}
 in
 	(debian|devuan)
-		# enable backports repo
-		# XXX: maybe the type should not be the one to decide whether or not to
-		# use backports
-		__apt_backports --component main --component contrib
-
 		# ZFS
-		read -r lsb_codename <"${__global:?}/explorer/lsb_codename"
-
 		kernel_headers_pkg=$(cat "${__object:?}/explorer/kernel_headers_pkg")
 		case ${kernel_headers_pkg}
 		in
@@ -73,20 +66,17 @@ in
 				exit 1
 				;;
 			(*/*)
-				require=__apt_backports/ \
 				__package_apt "${kernel_headers_pkg%%/*}" --target-release "${kernel_headers_pkg#*/}"
 				;;
 			(*)
-				require=__apt_backports/ \
 				__package_apt "${kernel_headers_pkg%%/*}"
 				;;
 		esac
 
-		require="__apt_backports/ __package_apt/${kernel_headers_pkg%%/*}" \
-		__package_apt zfs-modules --target-release "${lsb_codename:?}-backports"
+		require="__package_apt/${kernel_headers_pkg%%/*}" \
+		__package_apt zfs-modules
 
-		require=__apt_backports/ \
-		__package_apt zfsutils-linux --target-release "${lsb_codename:?}-backports"
+		__package_apt zfsutils-linux
 
 		# FIXME: For some reason De*an does not build/install DKMS modules after
 		# installing the package under some circumstances.
@@ -113,8 +103,8 @@ in
 				;;
 		esac
 
-		require="__apt_backports/ __package_apt/zfsutils-linux${mail_require:+ ${mail_require}}" \
-		__package_apt zfs-zed --target-release "${lsb_codename:?}-backports"
+		require="__package_apt/zfsutils-linux${mail_require:+ ${mail_require}}" \
+		__package_apt zfs-zed
 
 		require=__package_apt/zfs-zed \
 		__start_on_boot zfs-zed
@@ -157,7 +147,7 @@ then
 	fi
 	require=__package_apt/zfs-modules \
 	__block /etc/modprobe.d/zfs.conf:cdist-spl-workaround-11574 \
-		--state "$(test "${spl_kmem_cache_slab_limit-}" && echo present || echo absent)" \
+		--state "$(test -n "${spl_kmem_cache_slab_limit-}" && echo present || echo absent)" \
 		--file /etc/modprobe.d/zfs.conf \
 		--prefix '# cdist:spl-workaround-11574' \
 		--suffix '#/cdist:spl-workaround-11574' \
@@ -182,11 +172,11 @@ then
 
 	require= \
 	__block /etc/modprobe.d/zfs.conf:cdist-data-corruption-workaround \
-		--state "$(test "${zfs_dmu_offset_next_sync-}" && echo present || echo absent)" \
+		--state "$(test -n "${zfs_dmu_offset_next_sync-}" && echo present || echo absent)" \
 		--file /etc/modprobe.d/zfs.conf \
 		--prefix '# skonfig:zfs-corruption-mitigation' \
 		--suffix '#/skonfig:zfs-corruption-mitigation' \
-		-text - <<-EOF
+		--text - <<-EOF
 	options zfs zfs_dmu_offset_next_sync=$((zfs_dmu_offset_next_sync))
 	EOF
 fi


### PR DESCRIPTION
Let's leave this decision to the user.

Instead an example to install ZFS from Debian backports is added to `man.rst`.

This change is backwards-incompatible.
It does not affect existing installations, only new installations with the same manifest will, with this change, not install ZFS from backports anymore.