### PR TITLE
__letsencrypt_cert: Remove deprecated parameters

### DIFF
--- a/type/__letsencrypt_cert/files/gen_hook.sh
+++ b/type/__letsencrypt_cert/files/gen_hook.sh
@@ -29,13 +29,6 @@ hook_contents_head="#!/bin/sh -e"
 hook_contents_logic=""
 hook_contents_tail=""
 
-# Backwards compatibility
-# Remove this when renew-hook is removed
-# Falling back to renew-hook if deploy-hook is not passed
-if [ "${hook}" = "deploy" ] && [ ! -f "${hook_source}" ]
-then
-	hook_source="${__object:?}/parameter/renew-hook"
-fi
 if [ "${state}" = "present" ] && \
 	[ -f "${hook_source}" ]; then
 	# This hook is to be installed, let's generate it with some

--- a/type/__letsencrypt_cert/parameter/boolean
+++ b/type/__letsencrypt_cert/parameter/boolean
@@ -1,2 +1,1 @@
-automatic-renewal
 staging

--- a/type/__letsencrypt_cert/parameter/deprecated/automatic-renewal
+++ b/type/__letsencrypt_cert/parameter/deprecated/automatic-renewal
@@ -1,2 +1,0 @@
-Deprecated in favour of consistent behaviour. It has no effect, see:
-https://code.ungleich.ch/ungleich-public/cdist/-/issues/853

--- a/type/__letsencrypt_cert/parameter/deprecated/renew-hook
+++ b/type/__letsencrypt_cert/parameter/deprecated/renew-hook
@@ -1,2 +1,0 @@
-This parameter has been deprecated in favour of --deploy-hook.
-See: https://code.ungleich.ch/ungleich-public/cdist/-/issues/853

--- a/type/__letsencrypt_cert/parameter/optional_multiple
+++ b/type/__letsencrypt_cert/parameter/optional_multiple
@@ -2,4 +2,3 @@ deploy-hook
 domain
 post-hook
 pre-hook
-renew-hook


### PR DESCRIPTION
The `--automatic-renewal` and `--renew-hook` parameters were deprecated in 2021. After 4 years it's time to remove them for good.

Without having tested it, I think `--automatic-renewal` didn't even have any effect anymore.