### PR TITLE
__packages: always use __package to install or remove

### DIFF
--- a/type/__packages/man.rst
+++ b/type/__packages/man.rst
@@ -16,7 +16,8 @@ large number of packages.
 Additionally, since this type is used to install group of packages, then
 it can be used as a requirement for follow-up types.
 
-Currently only Debian, Ubuntu and Devuan are supported.
+Currently only Debian, Ubuntu and Devuan are supported
+(see ``explorer/present``).
 
 
 OPTIONAL MULTIPLE PARAMETERS
@@ -42,11 +43,11 @@ then using it as a requirement for follow-up types.
     export require='__packages/mpd'
 
     __systemd_unit mpd.service \
-        --enablement-disabled \
+        --enablement-state disabled \
         --restart
 
     __systemd_unit mpd.socket \
-        --enablement-disabled \
+        --enablement-state disabled \
         --restart
 
     unset require

--- a/type/__packages/manifest
+++ b/type/__packages/manifest
@@ -18,25 +18,6 @@
 # along with skonfig-extra. If not, see <http://www.gnu.org/licenses/>.
 #
 
-os=$(cat "${__global:?}/explorer/os")
-
-process_package() {
-    case "${os}"
-    in
-        (debian|ubuntu|devuan)
-            __package_apt "${1}" \
-                --state "${2}" \
-                --purge-if-absent \
-                </dev/null
-            ;;
-        (*)
-            __package "${1}" \
-                --state "${2}" \
-                </dev/null
-            ;;
-    esac
-}
-
 is_present="${__object:?}/explorer/present"
 should_present="${__object:?}/parameter/present"
 should_absent="${__object:?}/parameter/absent"
@@ -61,6 +42,9 @@ do
     | LC_ALL=C sort \
     | comm "$@" - "${is_present}" \
     | while read -r package_name
-    do process_package "${package_name}" "${package_state}"
+    do
+        __package "${package_name}" \
+            --state "${package_state}" \
+            </dev/null
     done
 done


### PR DESCRIPTION
It's pointless to create another logic here because `__package` already handles this.

And we can live without `--purge-if-absent` here (which should be default with `__package_apt` anyway).

Also doc fixes/updates.